### PR TITLE
Splitting an empty string does not make sense

### DIFF
--- a/sanitizer/templatetags/sanitizer.py
+++ b/sanitizer/templatetags/sanitizer.py
@@ -62,8 +62,8 @@ def allowtags(value, allowed=None, callback=None):
         if tag_name.startswith('-'):
             remove_tags.add(tag_name[1:])
             continue
-        allowed_attrs = allowed_attrs.split(',')
-        allowed_children = allowed_children.split(',')
+        allowed_attrs = allowed_attrs.split(',') if allowed_attrs else []
+        allowed_children = allowed_children.split(',') if allowed_children else []
         # SPECIAL CASE: tag:attrs[] means "no children allowed"
         # ommission of the [] at all means "any chidlren allowed"
         # allowed_children = [] if no children are allowed


### PR DESCRIPTION
In the lines 65 and 66 below, when no attributes/children are specified, it will always put a list containing an empty string `['']` in these variables. So in the line 73, the condition will in fact never be true.

```
65         allowed_attrs = allowed_attrs.split(',')
66         allowed_children = allowed_children.split(',')
67         # SPECIAL CASE: tag:attrs[] means "no children allowed"
68         # ommission of the [] at all means "any chidlren allowed"
69         # allowed_children = [] if no children are allowed
70         # allowed_children is None is no children are restricted
71         if tag_name.endswith('[]'):
72             allowed_children = []
73         elif not allowed_children:
74             allowed_children = None
75         valid_tags[tag_name] = (allowed_attrs, allowed_children)
```

For some reason this was causing some problems when handling nested not-well formed html tags, like `<ol><ol></ol></ol>`.
